### PR TITLE
radioコンポーネント追加

### DIFF
--- a/src/components/Checkbox.astro
+++ b/src/components/Checkbox.astro
@@ -19,8 +19,7 @@ const {
   disabled = false,
 } = Astro.props;
 ---
-<div
-  class=`c-check ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' }`>
+<div class=`c-check ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' }`>
   <input
     type="checkbox"
     id={id}
@@ -89,7 +88,7 @@ const {
         border: 2px solid var(--color-background-primary-emphasis);
 
         & + label {
-          color: var(--color-foreground-primary);
+          color: var(--color-foreground-body);
         }
       }
       

--- a/src/components/Radio.astro
+++ b/src/components/Radio.astro
@@ -1,0 +1,124 @@
+---
+interface Props {
+  id: string;
+  name: string;
+  value?: string;
+  checked?: boolean;
+  onChange?: (event: Event) => void;
+  error?: boolean;
+  disabled?: boolean;
+}
+
+const {
+  id,
+  name,
+  value = '',
+  checked = false,
+  onChange = () => {},
+  error = false,
+  disabled = false,
+} = Astro.props;
+---
+<div class=`c-radio ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' }`>
+  <input
+    type="radio"
+    id={id}
+    name={name}
+    value={value}
+    checked={checked}
+    :onchange={onChange}
+    disabled={disabled}
+  >
+  <label for={id}><slot /></label>
+</div>
+
+<style>
+  .c-radio {
+    &:focus-within {
+      outline: none;
+      box-shadow: var(--shadow-focus);
+    }
+
+    input {
+      border-radius: 0;
+      -webkit-appearance: none;
+        -moz-appearance: none;
+              appearance: none;
+    }
+
+    input:checked {
+      + label::before {
+        background: var(--color-background-primary-emphasis);
+        border: 2px solid var(--color-border-primary);
+      }
+
+      + label::after {
+        content: '';
+        position: absolute;
+        width: 0.5em;
+        height: 0.5em;
+        left: 0.38em;
+        top: calc(0.75em + 0.38em);
+        background: var(--color-foreground-on-fill);
+        border-radius: 50%;
+      }
+    }
+
+    label {
+      position: relative;
+      padding-inline: calc(1.25em + 1em);
+      padding-block: 0.75em;
+      cursor: pointer;
+      display: inline-block;
+      line-height: 20px;
+      border-radius: var(--round-s);
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0.75em;
+        width: 1.25em;
+        height: 1.25em;
+        border: 2px solid var(--color-border-default);
+        border-radius: 50%;
+        background: var(--color-background-on-fill);
+      }
+    }
+
+    &.error {
+      input:checked {
+        + label {
+          color: var(--color-foreground-body);
+        }
+      }
+
+      label {
+        color: var(--color-foreground-alert);
+      }
+
+      label::before {
+        border: 2px solid var(--color-border-alert);
+      }
+
+      label::after {
+        background: var(--color-background-alert);
+      }
+    }
+
+    &.disabled {
+      label {
+        color: var(--color-foreground-disabled);
+        cursor: not-allowed;
+      }
+
+      label::before {
+        border: 2px solid var(--color-border-disabled);
+      }
+
+      label::after {
+        background: var(--color-background-disabled);
+      }
+    }
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -30,6 +30,7 @@ const path = '/component-guide';
           <li><a href={`${path}/c-button`}>Button</a></li>
           <li><a href={`${path}/c-link`}>Link</a></li>
           <li><a href={`${path}/c-checkbox`}>Checkbox</a></li>
+          <li><a href={`${path}/c-radio`}>Radio</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-checkbox.astro
+++ b/src/pages/component-guide/c-checkbox.astro
@@ -6,81 +6,21 @@ import Checkbox from '../../components/Checkbox.astro'
 <ComponentGuideLayout title="Checkbox">
   <section>
     <div>
-      <Checkbox
-        id="checkbox1"
-        name="option1"
-        value="option1"
-      >
-        選択肢
-      </Checkbox>
+      <Checkbox id="checkbox1" name="option1" value="option1">選択肢</Checkbox>
     </div>
   </section>
   <section>
     <h3 class="heading-s">ステート</h3>
     <p>
-      ボタンの状態は6種類あります。<br>
+      ボタンの状態は5種類あります。<br>
       Default（デフォルト）、Focus（タブでフォーカス時）、Error（フォームエラー時）、Disable（利用不可）、Checked（選択時）
     </p>
     <ul class="list-vertical">
       <li>
-        <Checkbox
-          id="checkbox-error"
-          name="error"
-          value="Error"
-          error
-        >
-          Error
-        </Checkbox>
-        <Checkbox
-          id="checkbox-disable"
-          name="disable"
-          value="Disable"
-          disabled
-        >
-          Disabled
-        </Checkbox>
-        <Checkbox
-          id="checkbox-checked"
-          name="checked"
-          value="Checked"
-          checked
-        >
-          Checked
-        </Checkbox>
+        <Checkbox id="checkbox-error" name="error" value="Error" error>Error</Checkbox>
+        <Checkbox id="checkbox-disable" name="disable" value="Disable" disabled>Disabled</Checkbox>
+        <Checkbox id="checkbox-checked" name="checked" value="Checked" checked>Checked</Checkbox>
         </li>
     </div>
   </section>
-  <!-- <section>
-    <h3 class="heading-s">グループ</h3>
-    <p>
-      チェックボックスを並べる場合は縦に並べてください
-    </p>
-    <ul class="list-vertical">
-      <li>
-        <div class="group">
-          <Checkbox
-            id="checkbox-group1"
-            name="group"
-            value="option1"
-          >
-            選択肢
-          </Checkbox>
-          <Checkbox
-            id="checkbox-group2"
-            name="group"
-            value="option1"
-          >
-            選択肢
-          </Checkbox>
-          <Checkbox
-            id="checkbox-group3"
-            name="group"
-            value="option1"
-          >
-            選択肢
-          </Checkbox>
-        </div>
-      </li>
-    </ul>
-  </section> -->
 </ComponentGuideLayout>

--- a/src/pages/component-guide/c-radio.astro
+++ b/src/pages/component-guide/c-radio.astro
@@ -1,0 +1,24 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Radio from '../../components/Radio.astro'
+---
+<ComponentGuideLayout title="Checkbox">
+  <section>
+    <Radio id="option1" name="group1" value="選択肢">選択肢</Radio>
+  </section>
+  <section>
+    <h3 class="heading-s">ステート</h3>
+    <p>
+      ボタンの状態は5種類あります。<br>
+      Default（デフォルト）、Focus（タブでフォーカス時）、Error（フォームエラー時）、Disable（利用不可）、Checked（選択時）
+    </p>
+    <ul class="list-vertical">
+      <li>
+        <Radio id="state1" name="state" value="error" error>Error</Radio>
+        <Radio id="state2" name="state" value="disabled" disabled>Disabled</Radio>
+        <Radio id="state3" name="state" value="checked" checked>Checked</Radio>
+      </li>
+    </ul>
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
ラジオボタンコンポーネント追加

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=120%3A15035&mode=design&t=l3HjEKmoC32fRMGd-1)

## プレビュー
https://deploy-preview-10--ellie-in-house-portfolio.netlify.app/component-guide/c-radio/

## その他