### PR TITLE
selectboxコンポーネント追加

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -6,6 +6,7 @@ interface Props {
   size?: 'xsmall' | 'small' | 'medium' | 'large' | 'full';
 	href?: string;
   type?: 'button' | 'submit' | 'reset';
+  width?: string;
 }
 
 const {
@@ -14,15 +15,25 @@ const {
   disabled = false,
   size = 'medium',
   href,
-  type = 'button'
+  type = 'button',
+  width = 'auto'
 } = Astro.props;
 ---
 { href ?
-  <a class={`c-button ${variants} ${style} ${size} ${disabled ? disabled : ''}`} href={href}>
+  <a
+    class={`c-button ${variants} ${style} ${size} ${disabled ? disabled : ''}`}
+    href={href}
+    style={width !=="auto" ? `max-width: ${width}; width: 100%;` : ''}
+  >
     <slot />
   </a>
   :
-  <button class={`c-button ${variants} ${style} ${size} ${disabled ? disabled : ''}`} type={type} disabled={disabled}>
+  <button
+    class={`c-button ${variants} ${style} ${size} ${disabled ? disabled : ''}`}
+    type={type}
+    disabled={disabled}
+    style={width !=="auto" ? `max-width: ${width}; width: 100%;` : ''}
+  >
     <slot />
   </button>
 }

--- a/src/components/Radio.astro
+++ b/src/components/Radio.astro
@@ -66,8 +66,8 @@ const {
 
     label {
       position: relative;
-      padding-inline: calc(1.25em + 1em);
-      padding-block: 0.75em;
+      padding-inline: calc(1.25em + var(--space-s));
+      padding-block: var(--space-xs);
       cursor: pointer;
       display: inline-block;
       line-height: 20px;

--- a/src/components/Selectbox.astro
+++ b/src/components/Selectbox.astro
@@ -5,7 +5,7 @@ interface Props {
   onChange?: string;
   error?: boolean;
   disabled?: boolean;
-  fill?: boolean;
+  full?: boolean;
   width?: string;
 }
 
@@ -15,13 +15,13 @@ const {
   onChange,
   error = false,
   disabled = false,
-  fill = false,
+  full = false,
   width = 'auto'
 } = Astro.props;
 ---
 <div
-  class=`c-select ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' } ${ fill ? 'fill' : '' }`
-  style=`max-width: ${fill ? "100%" : width}`
+  class=`c-select ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' }`
+  style=`max-width: ${full ? "100%" : width}`
 >
   <select
     id={id}

--- a/src/components/Selectbox.astro
+++ b/src/components/Selectbox.astro
@@ -1,0 +1,93 @@
+---
+interface Props {
+  id: string;
+  name: string;
+  onChange?: string;
+  error?: boolean;
+  disabled?: boolean;
+  fill?: boolean;
+  width?: string;
+}
+
+const {
+  id,
+  name,
+  onChange,
+  error = false,
+  disabled = false,
+  fill = false,
+  width = 'auto'
+} = Astro.props;
+---
+<div
+  class=`c-select ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' } ${ fill ? 'fill' : '' }`
+  style=`max-width: ${fill ? "100%" : width}`
+>
+  <select
+    id={id}
+    name={name}
+    disabled={disabled}
+    onchange={onChange ? `window.${onChange}` : undefined}
+  >
+    <slot />
+  </select>
+</div>
+
+<style>
+  .c-select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+
+    width: 100%;
+    max-width: 200px;
+    position: relative;
+    z-index: 0;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 2em;
+      height: 100%;
+      background-image: url(data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiB2aWV3Qm94PSIwIDAgMjAgMjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMC4wMDAxIDEwLjk3NThMMTQuMTI1MSA2Ljg1MDgzTDE1LjMwMzQgOC4wM0wxMC4wMDAxIDEzLjMzMzNMNC42OTY3OCA4LjAzTDUuODc1MTEgNi44NTE2N0wxMC4wMDAxIDEwLjk3NThaIiBmaWxsPSIjMjIyMjIyIi8+Cjwvc3ZnPgo=);
+      background-repeat: no-repeat;
+      background-position: right 0.6em center;
+      position: absolute;
+      z-index: 1;
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: var(--shadow-focus);
+    }
+
+    select {
+      width: 100%;
+      padding: var(--space-xs) var(--space-xl) var(--space-xs) var(--space-s);
+      background: var(--color-background-default);
+      border: 1px solid var(--color-border-default);
+      border-radius: var(--round-s);
+    }
+
+    &.error {
+      select {
+        border: 1px solid var(--color-border-alert);
+      }
+    }
+
+    &.disabled {
+      background-color: var(--color-background-disabled);
+
+      &::before {
+        background-image: url(data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiB2aWV3Qm94PSIwIDAgMjAgMjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMC4wMDAxIDEwLjk3NThMMTQuMTI1MSA2Ljg1MDgzTDE1LjMwMzQgOC4wM0wxMC4wMDAxIDEzLjMzMzNMNC42OTY3OCA4LjAzTDUuODc1MTEgNi44NTE2NkwxMC4wMDAxIDEwLjk3NThaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjIiLz4KPC9zdmc+Cg==);
+        color: var(--color-foreground-disabled);
+      }
+
+      select {
+        cursor: not-allowed;
+      }
+    }
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -31,6 +31,7 @@ const path = '/component-guide';
           <li><a href={`${path}/c-link`}>Link</a></li>
           <li><a href={`${path}/c-checkbox`}>Checkbox</a></li>
           <li><a href={`${path}/c-radio`}>Radio</a></li>
+          <li><a href={`${path}/c-selectbox`}>Selectbox</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-button.astro
+++ b/src/pages/component-guide/c-button.astro
@@ -146,6 +146,8 @@ import Button from '../../components/Button.astro'
     最小幅は44pxです。<br>
     <br>
     コンテンツの幅に合わせてボタンの横幅を広げることもできます。<br>
+    <br>
+    サイズの他にmax-widthを文字列で指定できます。（できるだけ使わない）
   </p>
   <ul class="list-vertical" style="width: 100%">
     <li style="width: 100%">
@@ -168,6 +170,10 @@ import Button from '../../components/Button.astro'
       <Button size="full">
         <Icon type="share-box" />
         Full
+      </Button>
+      <Button width="500px">
+        <Icon type="share-box" />
+        max-width指定
       </Button>
     </li>
   </ul>

--- a/src/pages/component-guide/c-radio.astro
+++ b/src/pages/component-guide/c-radio.astro
@@ -3,7 +3,7 @@ import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
 
 import Radio from '../../components/Radio.astro'
 ---
-<ComponentGuideLayout title="Checkbox">
+<ComponentGuideLayout title="Radio">
   <section>
     <Radio id="option1" name="group1" value="選択肢">選択肢</Radio>
   </section>

--- a/src/pages/component-guide/c-selectbox.astro
+++ b/src/pages/component-guide/c-selectbox.astro
@@ -37,7 +37,7 @@ import Selectbox from '../../components/Selectbox.astro'
     <p>
       max-widthを文字列で指定できます。
       <br>
-      また、fillの追加で、コンテンツの幅に合わせてボタンの横幅を広げることもできます。
+      また、fullの追加で、コンテンツの幅に合わせてボタンの横幅を広げることもできます。
     </p>
     <ul class="list-vertical">
       <li>
@@ -46,7 +46,7 @@ import Selectbox from '../../components/Selectbox.astro'
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
         </Selectbox>
-        <Selectbox id="select" name="select" onChange="handleChange" fill>
+        <Selectbox id="select" name="select" onChange="handleChange" full>
           <option value="1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>

--- a/src/pages/component-guide/c-selectbox.astro
+++ b/src/pages/component-guide/c-selectbox.astro
@@ -1,0 +1,68 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Selectbox from '../../components/Selectbox.astro'
+---
+<ComponentGuideLayout title="Selectbox">
+  <section>
+    <Selectbox id="select" name="select" onChange="handleChange">
+      <option value="1">Option 1</option>
+      <option value="2">Option 2</option>
+      <option value="3">Option 3</option>
+    </Selectbox>
+  </section>
+  <section>
+    <h3 class="heading-s">ステート</h3>
+    <p>
+      状態は4種類あります。<br>
+      Default（デフォルト）、Focus（タブでフォーカス時）、Error（フォームエラー時）、Disabled（利用不可）
+    </p>
+    <ul class="list-vertical">
+      <li>
+        <Selectbox id="select" name="select" onChange="handleChange" error>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </Selectbox>
+        <Selectbox id="select" name="select" onChange="handleChange" disabled>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </Selectbox>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">サイズ</h3>
+    <p>
+      max-widthを文字列で指定できます。
+      <br>
+      また、fillの追加で、コンテンツの幅に合わせてボタンの横幅を広げることもできます。
+    </p>
+    <ul class="list-vertical">
+      <li>
+        <Selectbox id="select" name="select" onChange="handleChange" width="500px">
+          <option value="1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </Selectbox>
+        <Selectbox id="select" name="select" onChange="handleChange" fill>
+          <option value="1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </Selectbox>
+      </li>
+    </ul>
+  </section>
+</ComponentGuideLayout>
+
+<script type="module">
+  document.addEventListener('DOMContentLoaded', () => {
+    const selectElement = document.getElementById('select');
+    if (selectElement) {
+      selectElement.onchange = (event) => {
+        console.log(`選択された値: ${event.target.value}`);
+      };
+    }
+  });
+</script>


### PR DESCRIPTION
## 概要
selectboxコンポーネント追加
radioコンポーネント微調整
buttonコンポーネントにwidthのprops追加

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=120%3A15231&mode=design&t=l3HjEKmoC32fRMGd-1)

## プレビュー
https://deploy-preview-11--ellie-in-house-portfolio.netlify.app/component-guide/c-selectbox/

## その他