### PR TITLE
checkbox、radio、selectコンポーネントでdata属性でjsが動くよう調整

### DIFF
--- a/src/components/Checkbox.astro
+++ b/src/components/Checkbox.astro
@@ -4,7 +4,7 @@ interface Props {
   name: string;
   value?: string;
   checked?: boolean;
-  onChange?: (event: Event) => void;
+  dataOnchange?: string;
   error?: boolean;
   disabled?: boolean;
 }
@@ -14,7 +14,7 @@ const {
   name,
   value = '',
   checked = false,
-  onChange = () => {},
+  dataOnchange = '',
   error = false,
   disabled = false,
 } = Astro.props;
@@ -26,7 +26,7 @@ const {
     name={name}
     value={value}
     checked={checked}
-    :onchange={onChange}
+    data-onchange={dataOnchange}
     disabled={disabled}
   >
   <label for={id}><slot/></label>

--- a/src/components/Radio.astro
+++ b/src/components/Radio.astro
@@ -4,7 +4,7 @@ interface Props {
   name: string;
   value?: string;
   checked?: boolean;
-  onChange?: (event: Event) => void;
+  dataOnchange?: string;
   error?: boolean;
   disabled?: boolean;
 }
@@ -14,7 +14,7 @@ const {
   name,
   value = '',
   checked = false,
-  onChange = () => {},
+  dataOnchange = '',
   error = false,
   disabled = false,
 } = Astro.props;
@@ -26,7 +26,7 @@ const {
     name={name}
     value={value}
     checked={checked}
-    :onchange={onChange}
+    data-onchange={dataOnchange}
     disabled={disabled}
   >
   <label for={id}><slot /></label>

--- a/src/components/Selectbox.astro
+++ b/src/components/Selectbox.astro
@@ -2,7 +2,7 @@
 interface Props {
   id: string;
   name: string;
-  onChange?: string;
+  dataOnchange?: string;
   error?: boolean;
   disabled?: boolean;
   full?: boolean;
@@ -12,7 +12,7 @@ interface Props {
 const {
   id,
   name,
-  onChange,
+  dataOnchange = '',
   error = false,
   disabled = false,
   full = false,
@@ -20,21 +20,21 @@ const {
 } = Astro.props;
 ---
 <div
-  class=`c-select ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' }`
+  class=`c-selectbox ${ disabled ? 'disabled' : '' } ${ error ? 'error' : '' }`
   style=`max-width: ${full ? "100%" : width}`
 >
   <select
     id={id}
     name={name}
     disabled={disabled}
-    onchange={onChange ? `window.${onChange}` : undefined}
+    data-onchange={dataOnchange}
   >
     <slot />
   </select>
 </div>
 
 <style>
-  .c-select {
+  .c-selectbox {
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;

--- a/src/pages/component-guide/c-checkbox.astro
+++ b/src/pages/component-guide/c-checkbox.astro
@@ -6,7 +6,7 @@ import Checkbox from '../../components/Checkbox.astro'
 <ComponentGuideLayout title="Checkbox">
   <section>
     <div>
-      <Checkbox id="checkbox1" name="option1" value="option1">選択肢</Checkbox>
+      <Checkbox id="checkbox1" name="option1" value="選択肢" dataOnchange="handleChange">選択肢</Checkbox>
     </div>
   </section>
   <section>
@@ -17,10 +17,22 @@ import Checkbox from '../../components/Checkbox.astro'
     </p>
     <ul class="list-vertical">
       <li>
-        <Checkbox id="checkbox-error" name="error" value="Error" error>Error</Checkbox>
-        <Checkbox id="checkbox-disable" name="disable" value="Disable" disabled>Disabled</Checkbox>
-        <Checkbox id="checkbox-checked" name="checked" value="Checked" checked>Checked</Checkbox>
+        <Checkbox id="checkbox-error" name="error" value="Error" dataOnchange="handleChange" error>Error</Checkbox>
+        <Checkbox id="checkbox-disable" name="disable" value="Disable" dataOnchange="handleChange" disabled>Disabled</Checkbox>
+        <Checkbox id="checkbox-checked" name="checked" value="Checked" dataOnchange="handleChange" checked>Checked</Checkbox>
         </li>
     </div>
   </section>
 </ComponentGuideLayout>
+
+<script type="module">
+  document.addEventListener('DOMContentLoaded', () => {
+    const elements = document.querySelectorAll('.c-check [data-onchange="handleChange"]');
+
+    elements.forEach(element => {
+      element.onchange = (event) => {
+        console.log(`選択された値: ${event.target.value}`);
+      };
+    });
+  });
+</script>

--- a/src/pages/component-guide/c-radio.astro
+++ b/src/pages/component-guide/c-radio.astro
@@ -5,7 +5,7 @@ import Radio from '../../components/Radio.astro'
 ---
 <ComponentGuideLayout title="Radio">
   <section>
-    <Radio id="option1" name="group1" value="選択肢">選択肢</Radio>
+    <Radio id="option1" name="group1" value="選択肢" dataOnchange="handleChange">選択肢</Radio>
   </section>
   <section>
     <h3 class="heading-s">ステート</h3>
@@ -15,10 +15,22 @@ import Radio from '../../components/Radio.astro'
     </p>
     <ul class="list-vertical">
       <li>
-        <Radio id="state1" name="state" value="error" error>Error</Radio>
-        <Radio id="state2" name="state" value="disabled" disabled>Disabled</Radio>
-        <Radio id="state3" name="state" value="checked" checked>Checked</Radio>
+        <Radio id="state1" name="state" value="error" dataOnchange="handleChange" error>Error</Radio>
+        <Radio id="state2" name="state" value="disabled" dataOnchange="handleChange" disabled>Disabled</Radio>
+        <Radio id="state3" name="state" value="checked" dataOnchange="handleChange" checked>Checked</Radio>
       </li>
     </ul>
   </section>
 </ComponentGuideLayout>
+
+<script type="module">
+  document.addEventListener('DOMContentLoaded', () => {
+    const elements = document.querySelectorAll('.c-radio [data-onchange="handleChange"]');
+
+    elements.forEach(element => {
+      element.onchange = (event) => {
+        console.log(`選択された値: ${event.target.value}`);
+      };
+    });
+  });
+</script>

--- a/src/pages/component-guide/c-selectbox.astro
+++ b/src/pages/component-guide/c-selectbox.astro
@@ -5,7 +5,7 @@ import Selectbox from '../../components/Selectbox.astro'
 ---
 <ComponentGuideLayout title="Selectbox">
   <section>
-    <Selectbox id="select" name="select" onChange="handleChange">
+    <Selectbox id="select" name="select" dataOnchange="handleChange">
       <option value="1">Option 1</option>
       <option value="2">Option 2</option>
       <option value="3">Option 3</option>
@@ -19,12 +19,12 @@ import Selectbox from '../../components/Selectbox.astro'
     </p>
     <ul class="list-vertical">
       <li>
-        <Selectbox id="select" name="select" onChange="handleChange" error>
+        <Selectbox id="select" name="select" dataOnchange="handleChange" error>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
         </Selectbox>
-        <Selectbox id="select" name="select" onChange="handleChange" disabled>
+        <Selectbox id="select" name="select" dataOnchange="handleChange" disabled>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
@@ -41,12 +41,12 @@ import Selectbox from '../../components/Selectbox.astro'
     </p>
     <ul class="list-vertical">
       <li>
-        <Selectbox id="select" name="select" onChange="handleChange" width="500px">
+        <Selectbox id="select" name="select" dataOnchange="handleChange" width="500px">
           <option value="1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
         </Selectbox>
-        <Selectbox id="select" name="select" onChange="handleChange" full>
+        <Selectbox id="select" name="select" dataOnchange="handleChange" full>
           <option value="1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
@@ -58,11 +58,12 @@ import Selectbox from '../../components/Selectbox.astro'
 
 <script type="module">
   document.addEventListener('DOMContentLoaded', () => {
-    const selectElement = document.getElementById('select');
-    if (selectElement) {
-      selectElement.onchange = (event) => {
+    const elements = document.querySelectorAll('.c-selectbox [data-onchange="handleChange"]');
+
+    elements.forEach(element => {
+      element.onchange = (event) => {
         console.log(`選択された値: ${event.target.value}`);
       };
-    }
+    });
   });
 </script>


### PR DESCRIPTION
## 概要
checkbox、radio、selectコンポーネントでdata属性でjsが動くよう調整。

選択したものはconsole.logでvalueを表示するようにしてる。

## プレビュー
https://deploy-preview-12--ellie-in-house-portfolio.netlify.app/component-guide/c-checkbox/
https://deploy-preview-12--ellie-in-house-portfolio.netlify.app/component-guide/c-radio/
https://deploy-preview-12--ellie-in-house-portfolio.netlify.app/component-guide/c-selectbox/

## その他