### PR TITLE
form-helperコンポーネント追加

### DIFF
--- a/src/components/FormHelper/Label.astro
+++ b/src/components/FormHelper/Label.astro
@@ -1,0 +1,35 @@
+---
+interface Props {
+  label?: "none" | "required" | "optional";
+}
+
+const {
+  label = "none",
+} = Astro.props;
+---
+<legend class="c-form-helper-label">
+<slot />
+{ label === "required" ? <span class="required">必須</span> : label === "optional" ? <span class="optional">任意</span> : null}
+</legend>
+
+<style>
+  .c-form-helper-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-weight: bold;
+
+    span {
+      font-size: 0.75em;
+      font-weight: normal;
+    }
+
+    .required {
+      color: var(--color-foreground-alert);
+    }
+
+    .optional {
+      color: var(--color-foreground-description);
+    }
+  }
+</style>

--- a/src/components/FormHelper/Text.astro
+++ b/src/components/FormHelper/Text.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  error?: boolean;
+}
+
+const {
+  error = false
+} = Astro.props;
+---
+<p class=`c-form-helper-text text-body-s ${error ? 'error' : null}`><slot /></p>
+
+<style>
+  .c-form-helper-text {
+    color: var(--color-foreground-description);
+
+    &.error {
+      color: var(--color-foreground-alert);}
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -34,6 +34,7 @@ const path = '/component-guide';
           <li><a href={`${path}/c-selectbox`}>Selectbox</a></li>
           <li><a href={`${path}/c-input`}>Input</a></li>
           <li><a href={`${path}/c-textarea`}>Textarea</a></li>
+          <li><a href={`${path}/c-form-helper`}>FormHelper</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-form-helper.astro
+++ b/src/pages/component-guide/c-form-helper.astro
@@ -1,0 +1,39 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import FormHelperLabel from '../../components/FormHelper/Label.astro'
+import FormHelperText from '../../components/FormHelper/Text.astro'
+---
+<ComponentGuideLayout title="FormHelper">
+  <section>
+    <h3 class="heading-s">ラベル</h3>
+    <p>
+      3種類のバリエーションがあります。
+      ラベルはできるだけ必須か任意のついたものを使ってください。<br>
+      <br>
+      Default、Required（必須）、Any（任意）
+    </p>
+    <ul class="list-horizon">
+      <li>
+        <FormHelperLabel>ラベル</FormHelperLabel>
+        <FormHelperLabel label="required">ラベル</FormHelperLabel>
+        <FormHelperLabel label="optional">ラベル</FormHelperLabel>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">テキスト</h3>
+    <p>
+      フォームを補足するためのテキストです。<br>
+      <br>
+      Caption<br>
+      Error
+    </p>
+    <ul class="list-horizon">
+      <li>
+        <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+        <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+      </li>
+    </ul>
+  </section>
+</ComponentGuideLayout>

--- a/src/styles/styleguide.css
+++ b/src/styles/styleguide.css
@@ -105,7 +105,7 @@ h2 {
 
 .list-vertical > * {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   flex-wrap: wrap;
   gap: 20px;
   padding: var(--space-s);
@@ -115,7 +115,7 @@ h2 {
 
 .list-horizon > * {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   flex-direction: column;
   flex-wrap: wrap;
   gap: 20px;


### PR DESCRIPTION
## 概要
form-helperコンポーネント追加
チェックボックスやラジオの組み合わせは別ブランチで対応

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=120%3A15379&mode=design&t=l3HjEKmoC32fRMGd-1)

## プレビュー
https://deploy-preview-15--ellie-in-house-portfolio.netlify.app/component-guide/c-form-helper/

## その他