### PR TITLE
stackコンポーネント追加

### DIFF
--- a/src/components/Checkbox.astro
+++ b/src/components/Checkbox.astro
@@ -34,7 +34,8 @@ const {
 
 <style>
   .c-check {
-    display: inline-block;
+    width: 100%;
+    display: inline-flex;
     padding: var(--space-1-5);
     border-radius: var(--round-s);
 
@@ -75,6 +76,8 @@ const {
     }
 
     label {
+      display: inline-block;
+      width: 100%;
       padding-left: var(--space-xs);
     }
 

--- a/src/components/FormHelper/Text.astro
+++ b/src/components/FormHelper/Text.astro
@@ -7,7 +7,7 @@ const {
   error = false
 } = Astro.props;
 ---
-<p class=`c-form-helper-text text-body-s ${error ? 'error' : null}`><slot /></p>
+<p class=`c-form-helper-text text-caption ${error ? 'error' : null}`><slot /></p>
 
 <style>
   .c-form-helper-text {

--- a/src/components/Radio.astro
+++ b/src/components/Radio.astro
@@ -34,6 +34,8 @@ const {
 
 <style>
   .c-radio {
+    width: 100%;
+    display: inline-flex;
     &:focus-within {
       outline: none;
       box-shadow: var(--shadow-focus);
@@ -65,6 +67,7 @@ const {
     }
 
     label {
+      width: 100%;
       position: relative;
       padding-inline: calc(1.25em + var(--space-3)) var(--space-1-5);
       padding-block: var(--space-1-5);

--- a/src/components/Stack.astro
+++ b/src/components/Stack.astro
@@ -1,0 +1,113 @@
+---
+// TypeScript の型定義は Astro コンポーネントでは直接使えないため、コメントとして残します
+// type Breakpoint = 'sm' | 'md' | 'lg';
+
+// type BreakpointGaps = {
+//   [key in Breakpoint]?: number | string;
+// };
+
+// type BreakpointDirection = {
+//   [key in Breakpoint]?: string;
+// };
+
+// type BreakpointAlignItems = {
+//   [key in Breakpoint]?: string;
+// };
+
+// type BreakpointJustifyContent = {
+//   [key in Breakpoint]?: string;
+// };
+
+// interface Props {
+//   /** ID */
+//   id?: string;
+//   /** クラス名 */
+//   className?: string;
+//   /** 間隔 */
+//   gap?: string | number | BreakpointGaps;
+//   /** 折り返し */
+//   wrap?: boolean;
+//   /** フレックス方向 */
+//   direction?: "row" | "column" | BreakpointDirection;
+//   /** 縦方向の配置 */
+//   alignItems?: "flex-start" | "flex-end" | "center" | "baseline" | "stretch" | BreakpointAlignItems;
+//   /** 横方向の配置 */
+//   justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around" | "space-evenly" | BreakpointJustifyContent;
+//   /** タグ */
+//   as?: string;
+//   /** 幅 */
+//   width?: string | number | Record<Breakpoint, string | number>;
+// }
+
+const {
+  id,
+  className = "",
+  gap = "1rem",
+  wrap = false,
+  direction = "row",
+  alignItems = "flex-start",
+  justifyContent = "flex-start",
+  as: Tag = 'div',
+  width = "auto",
+} = Astro.props;
+
+const breakpoints = ['sm', 'md', 'lg'];
+
+let styles: Record<string, string> = {
+  '--stack-wrap': wrap ? 'wrap' : 'nowrap',
+};
+
+breakpoints.forEach((breakpoint) => {
+  if (typeof gap === 'object') {
+    styles[`--stack-gap-${breakpoint}`] = gap[breakpoint] ? `${gap[breakpoint]}` : '0';
+  } else {
+    styles[`--stack-gap-${breakpoint}`] = typeof gap === 'number' ? `${gap}` : gap;
+  }
+
+  const dir = typeof direction === 'object' ? direction[breakpoint] : direction;
+  styles[`--stack-direction-${breakpoint}`] = dir ? dir : 'row';
+
+  const align = typeof alignItems === 'object' ? alignItems[breakpoint] : alignItems;
+  styles[`--stack-alignItems-${breakpoint}`] = align ? align : 'flex-start';
+
+  const justify = typeof justifyContent === 'object' ? justifyContent[breakpoint] : justifyContent;
+  styles[`--stack-justifyContent-${breakpoint}`] = justify ? justify : 'flex-start';
+
+  const widthValue = typeof width === 'object' ? width[breakpoint] : width;
+  styles[`--stack-width-${breakpoint}`] = typeof widthValue === 'number' ? `${widthValue}px` : widthValue;
+});
+---
+
+<Tag id={id} class={`c-stack ${className}`} style={styles}>
+  <slot />
+</Tag>
+
+<style>
+  .c-stack {
+    display: flex;
+    width: 100%;
+    max-width: var(--stack-width-sm);
+    flex-wrap: var(--stack-wrap);
+    gap: var(--stack-gap-sm);
+    flex-direction: var(--stack-direction-sm);
+    align-items: var(--stack-alignItems-sm);
+    justify-content: var(--stack-justifyContent-sm);
+
+    /* 768px 以上 1199px 以下のデバイスに適用 */
+    @media (min-width: 768px) and (max-width: 1199px) {
+      max-width: var(--stack-width-md);
+      gap: var(--stack-gap-md);
+      flex-direction: var(--stack-direction-md);
+      align-items: var(--stack-alignItems-md);
+      justify-content: var(--stack-justifyContent-md);
+    }
+
+    @media (min-width: 1200px) {
+      max-width: var(--stack-width-lg);
+      gap: var(--stack-gap-lg);
+      flex-direction: var(--stack-direction-lg);
+      align-items: var(--stack-alignItems-lg);
+      justify-content: var(--stack-justifyContent-lg);
+    }
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -36,6 +36,7 @@ const path = '/component-guide';
           <li><a href={`${path}/c-textarea`}>Textarea</a></li>
           <li><a href={`${path}/c-form-helper`}>FormHelper</a></li>
           <li><a href={`${path}/c-skelton`}>Skelton</a></li>
+          <li><a href={`${path}/c-stack`}>Stack</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-form-helper.astro
+++ b/src/pages/component-guide/c-form-helper.astro
@@ -3,6 +3,13 @@ import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
 
 import FormHelperLabel from '../../components/FormHelper/Label.astro'
 import FormHelperText from '../../components/FormHelper/Text.astro'
+
+import Stack from '../../components/Stack.astro'
+import Checkbox from '../../components/Checkbox.astro'
+import Radio from '../../components/Radio.astro'
+import Selectbox from '../../components/Selectbox.astro'
+import Input from '../../components/Input.astro'
+import Textarea from '../../components/Textarea.astro'
 ---
 <ComponentGuideLayout title="FormHelper">
   <section>
@@ -33,6 +40,125 @@ import FormHelperText from '../../components/FormHelper/Text.astro'
       <li>
         <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
         <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">チェックボックス</h3>
+    <p>チェックボックスとの組み合わせ。</p>
+    <ul class="list-vertical">
+      <li>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="optional">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Stack direction="column" gap="0">
+            <Checkbox id="checkbox1" name="checkbox">ラベル</Checkbox>
+            <Checkbox id="checkbox2" name="checkbox">ラベル</Checkbox>
+            <Checkbox id="checkbox3" name="checkbox">ラベル</Checkbox>
+          </Stack>
+        </Stack>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="required">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Stack direction="column" gap="0">
+            <Checkbox id="checkbox1" name="checkbox" error>ラベル</Checkbox>
+            <Checkbox id="checkbox2" name="checkbox" error>ラベル</Checkbox>
+            <Checkbox id="checkbox3" name="checkbox" error>ラベル</Checkbox>
+          </Stack>
+          <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">ラジオボタン</h3>
+    <p>ラジオボタンとの組み合わせ。</p>
+    <ul class="list-vertical">
+      <li>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="optional">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Stack direction="column" gap="0">
+            <Radio id="radio1-1" name="radio-default">ラベル</Radio>
+            <Radio id="radio1-2" name="radio-default">ラベル</Radio>
+            <Radio id="radio1-3" name="radio-default">ラベル</Radio>
+          </Stack>
+        </Stack>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="required">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Stack direction="column" gap="0">
+            <Radio id="radio2-1" name="radio-required" error>ラベル</Radio>
+            <Radio id="radio2-2" name="radio-required" error>ラベル</Radio>
+            <Radio id="radio2-3" name="radio-required" error>ラベル</Radio>
+          </Stack>
+          <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">セレクトボックス</h3>
+    <p>セレクトボックスとの組み合わせ。</p>
+    <ul class="list-vertical">
+      <li>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="optional">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Selectbox id="select" name="select-optional" full>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+          </Selectbox>
+        </Stack>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="required">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Selectbox id="select" name="select-required" full error>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+          </Selectbox>
+          <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">テキスト入力</h3>
+    <p>テキスト入力との組み合わせ。</p>
+    <ul class="list-vertical">
+      <li>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="optional">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Input placeholder="プレースホルダー" full />
+        </Stack>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="required">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Input placeholder="プレースホルダー" full error />
+          <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">テキストエリア</h3>
+    <p>テキストエリアとの組み合わせ。</p>
+    <ul class="list-vertical">
+      <li>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="optional">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Textarea name="placeholder" placeholder="プレースホルダー" full />
+        </Stack>
+        <Stack direction="column" gap="0.75em">
+          <FormHelperLabel label="required">ラベル</FormHelperLabel>
+          <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
+          <Textarea name="placeholder" placeholder="プレースホルダー" full error />
+          <FormHelperText error>フォームのエラーが入ります</FormHelperText>
+        </Stack>
       </li>
     </ul>
   </section>

--- a/src/pages/component-guide/c-stack.astro
+++ b/src/pages/component-guide/c-stack.astro
@@ -1,0 +1,71 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Stack from '../../components/Stack.astro'
+import Skelton from '../../components/Skelton.astro'
+---
+<ComponentGuideLayout title="Stack">
+  <section>
+    <div>
+      <Stack>
+        <Skelton />
+        <Skelton />
+        <Skelton />
+      </Stack>
+    </div>
+  </section>
+  <section>
+    <h3 class="heading-s">ギャップ</h3>
+    <p>レスポンシブごとに間隔の指定ができます。</p>
+    <Stack gap={{ sm: '1em', md: '2em', lg: "3em" }}>
+      <Skelton />
+      <Skelton />
+      <Skelton />
+    </Stack>
+  </section>
+  <section>
+    <h3 class="heading-s">方向</h3>
+    <p>レスポンシブごとに方向の指定ができます。</p>
+    <Stack direction={{ sm: 'row', md: 'column', lg: "row" }}>
+      <Skelton />
+      <Skelton />
+      <Skelton />
+    </Stack>
+  </section>
+  <section>
+    <h3 class="heading-s">縦方向の配置</h3>
+    <p>レスポンシブごとに縦方向の配置の指定ができます。</p>
+    <Stack alignItems={{ sm: 'flex-start', md: 'flex-end', lg: "center" }}>
+      <Skelton />
+      <Skelton width="5em" height="5em" />
+      <Skelton />
+    </Stack>
+  </section>
+  <section>
+    <h3 class="heading-s">横方向の配置</h3>
+    <p>レスポンシブごとに縦方向の配置の指定ができます。</p>
+    <Stack justifyContent={{ sm: 'flex-start', md: 'flex-end', lg: "center" }}>
+      <Skelton width="5em" height="5em" />
+      <Skelton width="5em" height="5em" />
+      <Skelton width="5em" height="5em" />
+    </Stack>
+  </section>
+  <section>
+    <h3 class="heading-s">タグ</h3>
+    <p>asプロパティを使ってタグを変更できます。</p>
+    <Stack as="section">
+      <Skelton />
+      <Skelton />
+      <Skelton />
+    </Stack>
+  </section>
+  <section>
+    <h3 class="heading-s">幅</h3>
+    <p>レスポンシブごとに幅を指定できます。</p>
+    <Stack width={{ sm: "200px", md: "500px", lg: "1000px" }}>
+      <Skelton />
+      <Skelton />
+      <Skelton />
+    </Stack>
+  </section>
+</ComponentGuideLayout>

--- a/src/styles/styleguide.css
+++ b/src/styles/styleguide.css
@@ -24,6 +24,7 @@ a {
   border-bottom: 1px solid #ccc;
   position: sticky;
   top: 0;
+  z-index: 1;
   
   a {
     color: unset;


### PR DESCRIPTION
## 概要
stackコンポーネント追加
（flexboxでレスポンシブにプロパティをカスタムできるコンポーネント）

form-helperのドキュメント更新、それに伴うスタイル調整。

## プレビュー
https://deploy-preview-17--ellie-in-house-portfolio.netlify.app/component-guide/c-stack/
https://deploy-preview-17--ellie-in-house-portfolio.netlify.app/component-guide/c-form-helper/

## その他