### PR TITLE
modalコンポーネント追加

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,5 +1,7 @@
 ---
 interface Props {
+  id?: string;
+  className?: string;
   variants?: 'default' | 'primary' | 'success' | 'warning' | 'alert';
   style?: 'solid' | 'outline' | 'ghost' | 'link';
   disabled?: boolean;
@@ -7,32 +9,40 @@ interface Props {
 	href?: string;
   type?: 'button' | 'submit' | 'reset';
   width?: string;
+  dataOnclick?: string;
 }
 
 const {
+  id,
+  className,
   variants = 'default',
   style = 'solid',
   disabled = false,
   size = 'medium',
   href,
   type = 'button',
-  width = 'auto'
+  width = 'auto',
+  dataOnclick
 } = Astro.props;
 ---
 { href ?
   <a
-    class={`c-button ${variants} ${style} ${size} ${disabled ? disabled : ''}`}
+    {...(id ? { id: id } : {})}
+    class={`c-button ${className || ''} ${variants} ${style} ${size} ${disabled ? disabled : ''}`}
     href={href}
     style={width !=="auto" ? `max-width: ${width}; width: 100%;` : ''}
+    data-onclick={dataOnclick}
   >
     <slot />
   </a>
   :
   <button
-    class={`c-button ${variants} ${style} ${size} ${disabled ? disabled : ''}`}
+    {...(id ? { id: id } : {})}
+    class={`c-button ${className || ''} ${variants} ${style} ${size} ${disabled ? disabled : ''}`}
     type={type}
     disabled={disabled}
     style={width !=="auto" ? `max-width: ${width}; width: 100%;` : ''}
+    data-onclick={dataOnclick}
   >
     <slot />
   </button>

--- a/src/components/Modal/Modal.astro
+++ b/src/components/Modal/Modal.astro
@@ -1,0 +1,96 @@
+---
+interface Props {
+  id?: string;
+  className?: string;
+  ariaLabelledby?: string;
+  ariaDescribedby?: string;
+  tabIndex?: number;
+  hidden?: boolean;
+  modalId: string;
+}
+
+const {
+  /** ID */
+  id,
+  /** Class */
+  className,
+  /** モーダルのタイトル */
+  ariaLabelledby = "modalTitle",
+  /** モーダルの内容 */
+  ariaDescribedby = "modalDescription",
+  /** タブインデックス */
+  tabIndex = -1,
+  /** 非表示 */
+  hidden = true,
+  /** ボタンに紐づけるID */
+  modalId,
+} = Astro.props;
+---
+<div
+  {...(id ? { id: id } : {})}
+  class=`c-modal ${className || ''}`
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby={ariaLabelledby}
+  aria-describedby={ariaDescribedby}
+  tabindex={tabIndex}
+  hidden={hidden}
+  data-modalid={modalId}
+>
+  <slot />
+</div>
+
+<style>
+  .c-modal {
+    place-content: center;
+    width: 100vw;
+    height: 100dvh;
+    padding: var(--space-s);
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1;
+
+    &:not([hidden]) {
+      display: grid;
+    }
+  }
+</style>
+
+<script type="module">
+  document.addEventListener('DOMContentLoaded', () => {
+    const modals = document.querySelectorAll('.c-modal');
+    const triggerButtons = document.querySelectorAll('.c-button[data-onclick="openModal"]')
+
+    triggerButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const buttonId = button.getAttribute('id');
+        modals.forEach((modal) => {
+          const modalId = modal.getAttribute('data-modalid');
+          if (modalId === buttonId) {
+            modal.hidden = false;
+          }
+        })
+      });
+    });
+
+    // 閉じるボタンの処理
+    const closeButtons = document.querySelectorAll('.c-button[data-onclick="closeModal"]');
+    closeButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        console.log(button);
+        const modal = button.closest('.c-modal');
+        modal.hidden = true;
+      })
+    })
+
+    // オーバーレイの処理
+    const overlays = document.querySelectorAll('.c-modal-overlay');
+    overlays.forEach((overlay) => {
+      overlay.addEventListener('click', () => {
+        const modal = overlay.closest('.c-modal');
+        modal.hidden = true;
+      })
+    })
+  });
+</script>

--- a/src/components/Modal/ModalBody.astro
+++ b/src/components/Modal/ModalBody.astro
@@ -1,0 +1,14 @@
+---
+---
+<div class="c-modal-body text-body-m">
+  <slot />
+</div>
+
+<style>
+  .c-modal-body {
+    width: 100%;
+    max-height: 40vh;
+    padding: 0 var(--space-xl);
+    overflow-y: scroll;
+  }
+</style>

--- a/src/components/Modal/ModalButtons.astro
+++ b/src/components/Modal/ModalButtons.astro
@@ -1,0 +1,27 @@
+---
+---
+<div class="c-modal-buttons">
+  <slot />
+</div>
+
+<style>
+  .c-modal-buttons {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-xl);
+
+    > .c-button {
+      width: 100%;
+      max-width: 320px;
+      min-width: auto;
+    }
+
+    @media (min-width: 768px) {
+      flex-direction: row;
+    }
+  }
+</style>

--- a/src/components/Modal/ModalCloseButton.astro
+++ b/src/components/Modal/ModalCloseButton.astro
@@ -1,0 +1,6 @@
+---
+import Button from '../Button.astro';
+---
+<Button variants="default" style="outline" dataOnclick="closeModal">
+  閉じる
+</Button>

--- a/src/components/Modal/ModalContent.astro
+++ b/src/components/Modal/ModalContent.astro
@@ -1,0 +1,20 @@
+---
+---
+<div class="c-modal-content">
+  <slot />
+</div>
+
+<style>
+  .c-modal-content {
+    width: 100%;
+    margin: auto;
+    background: var(--color-background-default);
+    border-radius: var(--round-l);
+    position: relative;
+    z-index: 2;
+
+    @media (min-width: 768px) {
+      width: 624px;
+    }
+  }
+</style>

--- a/src/components/Modal/ModalHeading.astro
+++ b/src/components/Modal/ModalHeading.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  as?: string;
+}
+
+const {
+  as: Tag = 'div',
+} = Astro.props;
+---
+
+<Tag class="c-modal-heading heading-s">
+  <slot />
+</Tag>
+
+<style>
+  .c-modal-heading {
+    padding: var(--space-xl);
+  }
+</style>

--- a/src/components/Modal/ModalOverlay.astro
+++ b/src/components/Modal/ModalOverlay.astro
@@ -1,0 +1,15 @@
+---
+---
+<div class="c-modal-overlay"></div>
+
+<style>
+  .c-modal-overlay {
+    width: 100%;
+    height: 100%;
+    background: var(--color-overlay-backdrop);
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1;
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -39,6 +39,7 @@ const path = '/component-guide';
           <li><a href={`${path}/c-stack`}>Stack</a></li>
           <li><a href={`${path}/c-accordion`}>Accordion</a></li>
           <li><a href={`${path}/c-tab`}>Tab</a></li>
+          <li><a href={`${path}/c-modal`}>Modal</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-modal.astro
+++ b/src/pages/component-guide/c-modal.astro
@@ -1,0 +1,106 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Modal from '../../components/Modal/Modal.astro';
+import ModalContent from '../../components/Modal/ModalContent.astro';
+import ModalOverlay from '../../components/Modal/ModalOverlay.astro';
+import ModalHeading from '../../components/Modal/ModalHeading.astro';
+import ModalBody from '../../components/Modal/ModalBody.astro';
+import ModalButtons from '../../components/Modal/ModalButtons.astro';
+import ModalCloseButton from '../../components/Modal/ModalCloseButton.astro';
+
+import Button from '../../components/Button.astro';
+---
+
+<ComponentGuideLayout title="Modal">
+  <section>
+    <p>
+      モーダルは7つのコンポーネントで形成してます。<br>
+      <br>
+      Modal：モーダル全体のコンポーネント<br>
+      ModalOverlay：モーダルの背景を覆うオーバーレイ<br>
+      ModalContent：モーダルのコンテンツを包むコンポーネント<br>
+      ModalHeading：モーダルの見出し<br>
+      ModalBody：モーダルの本文<br>
+      ModalButtons：モーダルのボタンエリア<br>
+      ModalCloseButton：モーダルを閉じるボタン<br>
+      <br>
+      Buttonコンポーネントの`id`とModalコンポーネントの`modalId`で紐づけてください。
+    </p>
+    <div>
+      <Button id="modal1" variants="default" style="outline" dataOnclick="openModal">
+        モーダルを開く
+      </Button>
+      <Modal modalId="modal1">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeading>モーダル見出し</ModalHeading>
+          <ModalBody>
+            モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。
+          </ModalBody>
+          <ModalButtons>
+            <Button variants="primary" style="solid">
+              プライマリーボタン
+            </Button>
+            <ModalCloseButton />
+          </ModalButtons>
+        </ModalContent>
+      </Modal>
+    </div>
+  </section>
+  <section>
+    <h3 class="heading-s">見出し</h3>
+    <p>モーダルの見出しが入ります。</p>
+    <ul class="list-vertical">
+      <li style="width: 100%;">
+        <ModalHeading>モーダル見出し</ModalHeading>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">ボディ</h3>
+    <p>
+      モーダルの補助テキストが入ります。<br>
+      <br>
+      もし、モーダルの高さがデバイスの高さを超える場合、コンテンツはY軸にスクロールして閲覧できるようにします。
+    </p>
+    <ul class="list-horizon">
+      <li>
+        <ModalBody>
+          モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。モーダルの補助テキストが入ります。
+        </ModalBody>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">閉じるボタン</h3>
+    <ul class="list-vertical">
+      <li style="width: 100%;">
+        <ModalCloseButton />
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">ボタンエリア</h3>
+    <p>
+      モーダルを操作するボタンエリアです。<br>
+      閉じるボタンは必ず入れてください。<br>
+      <br>
+      ボタンは閉じるボタンのみと、何かしら決定するためのボタンを含んだものがあります。<br>
+      （プライマリーボタンの他にサクセスやアラートボタンに代替できます）
+    </p>
+    <ul class="list-vertical">
+      <li style="width: 100%;">
+        <ModalButtons>
+          <ModalCloseButton />
+        </ModalButtons>
+        <ModalButtons>
+          <Button variants="primary" style="solid">
+            プライマリーボタン
+          </Button>
+          <ModalCloseButton />
+        </ModalButtons>
+      </li>
+    </ul>
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
- modalコンポーネント追加
- buttonにprops追加

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=132%3A2522&mode=design&t=sX1kpV5xUQ93ahHu-1)

## プレビュー
https://deploy-preview-20--ellie-in-house-portfolio.netlify.app/component-guide/c-modal/

## その他