### PR TITLE
listコンポーネント追加

### DIFF
--- a/src/components/List.astro
+++ b/src/components/List.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+  variants?: 'default' | 'unordered' | 'ordered' | 'check';
+}
+
+const {
+  variants = 'default'
+} = Astro.props
+---
+<li class=`c-list text-body-m ${variants}`>
+  <slot />
+</li>
+
+<style>
+  .c-list {
+    list-style-type: none;
+    padding: var(--space-base);
+
+    &.unordered {
+      list-style-type: disc;
+      margin-left: 1.5em;
+    }
+
+    &.ordered {
+      margin-left: 1.5em;
+      list-style-type: decimal;
+    }
+
+    &.check {
+      text-indent: -1.5em;
+      margin-left: 1.5em;
+
+      &::before {
+        display: inline-block;
+        content: '';
+        width: 1.25em;
+        height: 1.25em;
+        margin-right: 0.25em;
+        margin-bottom: 0.25em;
+        vertical-align: middle;
+        background-color: var(--color-background-primary-emphasis);
+        background-image: url('data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMTYgMTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik02LjY2NjUgMTAuMTEzM0wxMi43OTQ1IDMuOTg1OTZMMTMuNzM3MiA0LjkyODYzTDYuNjY2NSAxMS45OTkzTDIuNDIzODMgNy43NTY2M0wzLjM2NjUgNi44MTM5Nkw2LjY2NjUgMTAuMTEzM1oiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=');
+        background-repeat: no-repeat;
+        background-position: center;
+        border-radius: 50%;
+      }
+    }
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -41,6 +41,7 @@ const path = '/component-guide';
           <li><a href={`${path}/c-tab`}>Tab</a></li>
           <li><a href={`${path}/c-modal`}>Modal</a></li>
           <li><a href={`${path}/c-divider`}>Divider</a></li>
+          <li><a href={`${path}/c-list`}>List</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-list.astro
+++ b/src/pages/component-guide/c-list.astro
@@ -1,0 +1,75 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import List from '../../components/List.astro'
+import Stack from '../../components/Stack.astro'
+---
+
+<ComponentGuideLayout title="List">
+  <section>
+    <ul class="list-vertical">
+      <li style="width: 100%;">
+        <Stack as="ul" direction="column">
+          <List>リスト項目</List>
+          <List>リスト項目</List>
+          <List>リスト項目</List>
+        </Stack>
+        <Stack as="ul" direction="column">
+          <List variants="unordered">リスト項目</List>
+          <List variants="unordered">リスト項目</List>
+          <List variants="unordered">リスト項目</List>
+        </Stack>
+        <Stack as="ul" direction="column">
+          <List variants="ordered">リスト項目</List>
+          <List variants="ordered">リスト項目</List>
+          <List variants="ordered">リスト項目</List>
+        </Stack>
+        <Stack as="ul" direction="column">
+          <List variants="check">リスト項目</List>
+          <List variants="check">リスト項目</List>
+          <List variants="check">リスト項目</List>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">デフォルト</h3>
+    <ul class="list-vertical">
+      <li>
+        <Stack as="ul" direction="column">
+          <List>リスト項目</List>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">順序なしリスト</h3>
+    <ul class="list-vertical">
+      <li>
+        <Stack as="ul" direction="column">
+          <List variants="unordered">リスト項目</List>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">順序ありリスト</h3>
+    <ul class="list-vertical">
+      <li>
+        <Stack as="ol" direction="column">
+          <List variants="ordered">リスト項目</List>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+  <section>
+    <h3 class="heading-s">チェックマーク付きリスト</h3>
+    <ul class="list-vertical">
+      <li>
+        <Stack as="ul" direction="column">
+          <List variants="check">リスト項目</List>
+        </Stack>
+      </li>
+    </ul>
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
listコンポーネント追加

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=138%3A7309&mode=design&t=3A8U4EXAv1g8CJ57-1)

## プレビュー
https://deploy-preview-22--ellie-in-house-portfolio.netlify.app/component-guide/c-list/

## その他