### PR TITLE
Safariのスタイル崩れ調整

### DIFF
--- a/src/components/Checkbox.astro
+++ b/src/components/Checkbox.astro
@@ -44,7 +44,7 @@ const {
       box-shadow: var(--shadow-focus);
     }
 
-    input[type="checkbox"] {
+    > input[type="checkbox"] {
       border-radius: 0;
       -webkit-appearance: none;
         -moz-appearance: none;
@@ -58,7 +58,7 @@ const {
       vertical-align: -5px;
     }
 
-    input[type="checkbox"]:checked {
+    > input[type="checkbox"]:checked {
       background: var(--color-background-primary-emphasis);
       border: 2px solid var(--color-background-primary-emphasis);
 
@@ -75,18 +75,18 @@ const {
       }
     }
 
-    label {
+    > label {
       display: inline-block;
       width: 100%;
       padding-left: var(--space-xs);
     }
 
     &.error {
-      input[type="checkbox"] {
+      > input[type="checkbox"] {
         border: 2px solid var(--color-border-alert);
       }
 
-      input[type="checkbox"]:checked {
+      > input[type="checkbox"]:checked {
         background: var(--color-background-primary-emphasis);
         border: 2px solid var(--color-background-primary-emphasis);
 
@@ -101,12 +101,12 @@ const {
     }
 
     &.disabled {
-      input[type="checkbox"] {
+      > input[type="checkbox"] {
         border: 2px solid var(--color-border-disabled);
         pointer-events: none;
       }
       
-      label {
+      > label {
         color: var(--color-foreground-disabled);
       }
     }

--- a/src/components/FormHelper/Label.astro
+++ b/src/components/FormHelper/Label.astro
@@ -19,7 +19,7 @@ const {
     gap: var(--space-2);
     font-weight: bold;
 
-    span {
+    > span {
       font-size: 0.75em;
       font-weight: normal;
     }

--- a/src/components/Radio.astro
+++ b/src/components/Radio.astro
@@ -41,14 +41,14 @@ const {
       box-shadow: var(--shadow-focus);
     }
 
-    input {
+    > input {
       border-radius: 0;
       -webkit-appearance: none;
         -moz-appearance: none;
               appearance: none;
     }
 
-    input:checked {
+    > input:checked {
       + label::before {
         background: var(--color-background-primary-emphasis);
         border: 2px solid var(--color-border-primary);
@@ -66,7 +66,7 @@ const {
       }
     }
 
-    label {
+    > label {
       width: 100%;
       position: relative;
       padding-inline: calc(1.25em + var(--space-3)) var(--space-1-5);
@@ -90,36 +90,36 @@ const {
     }
 
     &.error {
-      input:checked {
+      > input:checked {
         + label {
           color: var(--color-foreground-body);
         }
       }
 
-      label {
+      > label {
         color: var(--color-foreground-alert);
       }
 
-      label::before {
+      > label::before {
         border: 2px solid var(--color-border-alert);
       }
 
-      label::after {
+      > label::after {
         background: var(--color-background-alert);
       }
     }
 
     &.disabled {
-      label {
+      > label {
         color: var(--color-foreground-disabled);
         cursor: not-allowed;
       }
 
-      label::before {
+      > label::before {
         border: 2px solid var(--color-border-disabled);
       }
 
-      label::after {
+      > label::after {
         background: var(--color-background-disabled);
       }
     }

--- a/src/components/Selectbox.astro
+++ b/src/components/Selectbox.astro
@@ -63,7 +63,7 @@ const {
       box-shadow: var(--shadow-focus);
     }
 
-    select {
+    > select {
       width: 100%;
       padding: var(--space-1-5) var(--space-4) var(--space-1-5) var(--space-2);
       background: var(--color-background-default);
@@ -72,7 +72,7 @@ const {
     }
 
     &.error {
-      select {
+      > select {
         border: 1px solid var(--color-border-alert);
       }
     }
@@ -85,7 +85,7 @@ const {
         color: var(--color-foreground-disabled);
       }
 
-      select {
+      > select {
         cursor: not-allowed;
       }
     }

--- a/src/pages/component-guide/c-form-helper.astro
+++ b/src/pages/component-guide/c-form-helper.astro
@@ -61,9 +61,9 @@ import Textarea from '../../components/Textarea.astro'
           <FormHelperLabel label="required">ラベル</FormHelperLabel>
           <FormHelperText>フォームをサポートするテキストが入ります</FormHelperText>
           <Stack direction="column" gap="0">
-            <Checkbox id="checkbox1" name="checkbox" error>ラベル</Checkbox>
-            <Checkbox id="checkbox2" name="checkbox" error>ラベル</Checkbox>
-            <Checkbox id="checkbox3" name="checkbox" error>ラベル</Checkbox>
+            <Checkbox id="checkbox4" name="checkbox" error>ラベル</Checkbox>
+            <Checkbox id="checkbox5" name="checkbox" error>ラベル</Checkbox>
+            <Checkbox id="checkbox6" name="checkbox" error>ラベル</Checkbox>
           </Stack>
           <FormHelperText error>フォームのエラーが入ります</FormHelperText>
         </Stack>

--- a/src/styles/styleguide.css
+++ b/src/styles/styleguide.css
@@ -48,6 +48,7 @@ a {
   background: #fff;
   overflow-y: auto;
   position: sticky;
+  z-index: 1000;
   top: var(--header-height);
 
   @media (max-width: 768px) {
@@ -59,7 +60,7 @@ a {
     border-bottom: 1px solid #ccc;
   }
 
-  ul {
+  > ul {
     display: flex;
     flex-direction: column;
 
@@ -67,11 +68,13 @@ a {
       flex-direction: row;
       gap: 16px;
     }
-  }
 
-  a {
-    display: block;
-    padding: 12px 0;
+    > li {
+      > a {
+        display: block;
+        padding: 12px 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 概要
`>`を指定しないとスタイリングできないようだったので調整。

## プレビュー
https://deploy-preview-25--ellie-in-house-portfolio.netlify.app/component-guide

## その他