### PR TITLE
typographyコンポーネント追加

### DIFF
--- a/src/components/Modal/ModalHeading.astro
+++ b/src/components/Modal/ModalHeading.astro
@@ -1,16 +1,12 @@
 ---
-interface Props {
-  as?: string;
-}
-
-const {
-  as: Tag = 'div',
-} = Astro.props;
+import Typography from '../Typography.astro';
 ---
 
-<Tag class="c-modal-heading heading-s">
-  <slot />
-</Tag>
+<div class="c-modal-heading">
+  <Typography size="heading-s">
+    <slot />
+  </Typography>
+</div>
 
 <style>
   .c-modal-heading {

--- a/src/components/SectionHeading/SectionHeadingMain.astro
+++ b/src/components/SectionHeading/SectionHeadingMain.astro
@@ -1,5 +1,6 @@
 ---
+import Typography from '../Typography.astro';
 ---
-<div class="c-section-heading-main heading-display">
+<Typography className="c-section-heading-main" size="heading-display">
   <slot />
-</div>
+</Typography>

--- a/src/components/SectionHeading/SectionHeadingSub.astro
+++ b/src/components/SectionHeading/SectionHeadingSub.astro
@@ -1,11 +1,6 @@
 ---
+import Typography from '../Typography.astro';
 ---
-<div class="c-section-heading-sub text-label-s">
+<Typography className="c-section-heading-sub" size="label-s" color="description">
   <slot />
-</div>
-
-<style>
-  .c-section-heading-sub {
-    color: var(--color-foreground-description);
-  }
-</style>
+</Typography>

--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -1,0 +1,163 @@
+---
+interface Props {
+  id?: string;
+  className?: string;
+  as?: string;
+  size?: 'display' | 'heading-l' | 'heading-m' | 'heading-s' | 'heading-xs' | 'body-l' | 'body-m' | 'body-s' | 'label-l' | 'label-m' | 'label-s' | 'label-xs' | 'caption' | 'button';
+  /** 太字かどうか */
+  weight?: 'normal' | 'medium' | 'bold';
+  /** テキストの位置 */
+  align?: 'left' | 'center' | 'right';
+  /** 文字色 */
+  color?: 'body' | 'description'| string;
+}
+
+const {
+  id,
+  className = "",
+  as: Tag = 'p',
+  size = 'body-m',
+  weight = 'normal',
+  align = 'left',
+  color = 'body',
+} = Astro.props;
+---
+<Tag
+  id={id}
+  class=`c-typography ${size} ${weight} ${className || ''} `
+  style={`text-align: ${align}; color: ${color ? `var(--color-foreground-${color})` : 'inherit'};`}
+>
+  <slot />
+</Tag>
+
+<style>
+  .c-typography {
+    &.display {
+      font-size: 4rem;
+      font-weight: bold;
+      line-height: 1.4;
+      letter-spacing: 0.04em;
+    }
+
+    &.heading-l {
+      font-size: 3.2rem;
+      font-weight: 500;
+      line-height: 1.4;
+      letter-spacing: 0.04em;
+    }
+
+    &.heading-m {
+      font-size: 2.4rem;
+      font-weight: bold;
+      line-height: 1.4;
+      letter-spacing: 0.04em;
+    }
+
+    &.heading-s {
+      font-size: 2rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.heading-xs {
+      font-size: 1.6rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.body-l {
+      font-size: 1.8rem;
+      font-weight: normal;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.body-m {
+      font-size: 1.6rem;
+      font-weight: normal;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.body-s {
+      font-size: 1.4rem;
+      font-weight: normal;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.label-l {
+      font-size: 1.8rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.label-m {
+      font-size: 1.6rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.label-s {
+      font-size: 1.4rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.02em;
+    }
+
+    &.label-xs {
+      font-size: 1.2rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.02em;
+    }
+
+    &.caption {
+      font-size: 1.2rem;
+      font-weight: normal;
+      line-height: 1.6;
+      letter-spacing: 0.02em;
+    }
+
+    &.button {
+      font-size: 1.6rem;
+      font-weight: bold;
+      line-height: 1.6;
+      letter-spacing: 0.04em;
+    }
+
+    &.medium {
+      font-weight: 500;
+    }
+
+    &.bold {
+      font-weight: 700;
+    }
+
+    @media (min-width: 768px) {
+      &.display {
+        font-size: clamp(4rem, 2vw + 3rem, 6.4rem);
+      }
+
+      &.heading-l {
+        font-size: clamp(3.2rem, 2vw + 2rem, 4rem);
+      }
+
+      &.heading-m {
+        font-size: clamp(2.4rem, 2vw + 1.2rem, 3.2rem);
+      }
+
+      &.heading-s {
+        font-size: clamp(2rem, 2vw + 0.6rem, 2.4rem);
+      }
+
+      &.heading-xs {
+        font-size: clamp(1.6rem, 2vw, 1.8rem);
+      }
+    }
+  }
+</style>

--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -10,6 +10,8 @@ interface Props {
   align?: 'left' | 'center' | 'right';
   /** 文字色 */
   color?: 'body' | 'description'| string;
+  /** フォントファミリー */
+  family?: 'ja' | 'en';
 }
 
 const {
@@ -20,11 +22,12 @@ const {
   weight = 'normal',
   align = 'left',
   color = 'body',
+  family = 'ja',
 } = Astro.props;
 ---
 <Tag
   id={id}
-  class=`c-typography ${size} ${weight} ${className || ''} `
+  class=`c-typography ${size} ${weight} ${family} ${className || ''} `
   style={`text-align: ${align}; color: ${color ? `var(--color-foreground-${color})` : 'inherit'};`}
 >
   <slot />
@@ -136,6 +139,10 @@ const {
 
     &.bold {
       font-weight: 700;
+    }
+
+    &.en {
+      font-family: var(--font-family-en);
     }
 
     @media (min-width: 768px) {

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -44,6 +44,7 @@ import SwitchTheme from '../components/Switch/SwitchTheme.astro';
           <li><a href={`${path}/c-icon`}>Icon</a></li>
           <li><a href={`${path}/c-cando-icon`}>CandoIcon</a></li>
           <li><a href={`${path}/c-image`}>Image</a></li>
+          <li><a href={`${path}/c-typography`}>Typography</a></li>
           <li><a href={`${path}/c-button`}>Button</a></li>
           <li><a href={`${path}/c-link`}>Link</a></li>
           <li><a href={`${path}/c-checkbox`}>Checkbox</a></li>

--- a/src/pages/component-guide/c-typography.astro
+++ b/src/pages/component-guide/c-typography.astro
@@ -93,4 +93,15 @@ import Typography from '../../components/Typography.astro'
       </Typography>
     </div>
   </section>
+  <section>
+    <h3 class="heading-s">フォントファミリー</h3>
+    <div>
+      <Typography>
+        日本語
+      </Typography>
+      <Typography family="en">
+        English
+      </Typography>
+    </div>
+  </section>
 </ComponentGuideLayout>

--- a/src/pages/component-guide/c-typography.astro
+++ b/src/pages/component-guide/c-typography.astro
@@ -1,0 +1,96 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Typography from '../../components/Typography.astro'
+---
+<ComponentGuideLayout title="Typography">
+  <section>
+    <h3 class="heading-s">見出し</h3>
+    <div>
+      <Typography size="display">
+        ディスプレイ
+      </Typography>
+      <Typography size="heading-l">
+        見出しL
+      </Typography>
+      <Typography size="heading-m">
+        見出しM
+      </Typography>
+      <Typography size="heading-s">
+        見出しS
+      </Typography>
+      <Typography size="heading-xs">
+        見出しXS
+      </Typography>
+    </div>
+  </section>
+  <section>
+    <h3 class="heading-s">その他のテキストスタイル</h3>
+    <div>
+      <Typography size="body-l">
+        本文L
+      </Typography>
+      <Typography size="body-l" wight="bold">
+        本文L 太字
+      </Typography>
+      <Typography size="body-m">
+        本文M
+      </Typography>
+      <Typography size="body-m" weight="bold">
+        本文M 太字
+      </Typography>
+      <Typography size="body-s">
+        本文S
+      </Typography>
+      <Typography size="body-s" weight="bold">
+        本文S 太字
+      </Typography>
+      <Typography size="label-l">
+        ラベルL
+      </Typography>
+      <Typography size="label-m">
+        ラベルM
+      </Typography>
+      <Typography size="label-s">
+        ラベルS
+      </Typography>
+      <Typography size="label-xs">
+        ラベルXS
+      </Typography>
+      <Typography size="caption">
+        注釈
+      </Typography>
+      <Typography size="caption" weight="bold">
+        注釈 太字
+      </Typography>
+      <Typography size="button">
+        ボタン
+      </Typography>
+    </div>
+  </section>
+  <section>
+    <h3 class="heading-s">フォントカラー</h3>
+    <div>
+      <Typography>
+        本文カラー
+      </Typography>
+      <Typography color="description">
+        説明文カラー
+      </Typography>
+    </div>
+  </section>
+  <section>
+    <h3 class="heading-s">テキストの位置</h3>
+    <div>
+      <Typography>
+        左揃え
+      </Typography>
+      <Typography align="center">
+        中央揃え
+      </Typography>
+      <Typography align="right">
+        右揃え
+      </Typography>
+    </div>
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
typographyコンポーネント追加

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=26%3A2626&mode=design&t=owV2O5zTp18aT6mp-1)

## プレビュー
https://deploy-preview-38--ellie-in-house-portfolio.netlify.app/component-guide/c-typography/

## その他