### PR TITLE
ヘッダー関連のコンポーネント追加

### DIFF
--- a/src/components/Hamburger.astro
+++ b/src/components/Hamburger.astro
@@ -1,0 +1,52 @@
+---
+---
+<div class="c-hamburger" role="button" aria-pressed="false">
+  <div class="inner">
+    <span class="line"></span>
+    <span class="line"></span>
+  </div>
+</div>
+
+<style>
+.c-hamburger {
+  width: 6.4rem;
+  height: 4rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--round-full);
+  cursor: pointer;
+
+  @media screen and (min-width: 768px) {
+    display: none;
+  }
+
+  .inner {
+    width: 2rem;
+    height: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .line {
+    display: block;
+    width: 100%;
+    height: 1px;
+    background-color: var(--color-foreground-body);
+    transition: .4s;
+  }
+
+  &.is-expanded {
+    .line {
+      &:first-child {
+        transform: rotate(45deg) translate(0.3rem, 0.3rem);
+      }
+
+      &:last-child {
+        transform: rotate(-45deg) translate(0.2rem, -0.2rem);
+      }
+    }
+  }
+}
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,90 @@
+---
+import Navigation from './Navigation.astro';
+import SwitchTheme from './Switch/SwitchTheme.astro';
+import Hamburger from './Hamburger.astro';
+---
+<header class="c-header">
+  <Navigation />
+  <SwitchTheme />
+  <Hamburger />
+</header>
+
+<script type="module">
+  const navigation = document.querySelector('.c-navigation');
+  const hamburger = document.querySelector('.c-hamburger');
+
+  document.querySelector('.c-hamburger').addEventListener('click', () => {
+    navigation.classList.toggle('is-expanded');
+    hamburger.classList.toggle('is-expanded');
+
+    if(hamburger.classList.contains('is-expanded')) {
+      hamburger.setAttribute('aria-pressed', true);
+    } else {
+      hamburger.setAttribute('aria-pressed', false);
+    }
+  });
+</script>
+
+<style>
+  .c-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-xs-2) var(--space-xs);
+    position: relative;
+    z-index: 1000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 2;
+
+    .c-navigation {
+      display: none;
+      width: 100vw;
+      height: 100svh;
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: -1;
+
+      .lists {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+
+        &::after {
+          content: "";
+          width: 100%;
+          height: 100%;
+          background: var(--color-background-default);
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: -1;
+        }
+      }
+    }
+
+    .c-navigation.is-expanded {
+      display: block;
+    }
+
+    @media (min-width: 768px) {
+      .c-navigation {
+        display: block;
+        width: auto;
+        height: auto;
+        position: relative;
+
+        .lists {
+          &::after {
+            display: none;
+          }
+        }
+      }
+    }
+  }
+</style>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,0 +1,59 @@
+---
+import Stack from "./Stack.astro";
+import Typography from "./Typography.astro";
+import Button from "./Button.astro";
+---
+<nav class="c-navigation">
+  <ul class="lists">
+    <li>
+      <Button href="#" style="ghost" size="small">プロフィール</Button>
+    </li>
+    <li>
+      <Button href="#" style="ghost" size="small">スキル</Button>
+    </li>
+    <li>
+      <Button href="#" style="ghost" size="small">相談できること</Button>
+    </li>
+    <li>
+      <Button href="#" style="ghost" size="small">制作物</Button>
+    </li>
+  </ul>
+</nav>
+
+<style>
+  .c-navigation {
+    /* display: none; */
+
+    .lists {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.8rem;
+      padding: var(--space-s);
+    }
+
+    .lists li,
+    .lists li a {
+      width: 100%;
+    }
+
+    &.is-expanded {
+      display: block;
+    }
+
+    @media screen and (min-width: 768px) {
+      display: block;
+
+      .lists {
+        flex-direction: row;
+        align-items: flex-start;
+        padding: 0;
+      }
+
+      .lists li,
+      .lists li a {
+        width: auto;
+      }
+    }
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -69,6 +69,9 @@ import SwitchTheme from '../components/Switch/SwitchTheme.astro';
           <li><a href={`${path}/c-skill-item`}>SkillItem</a></li>
           <li><a href={`${path}/c-work-thumbnail`}>WorkThumbnail</a></li>
           <li><a href={`${path}/c-work-item`}>WorkItem</a></li>
+          <li><a href={`${path}/c-navigation`}>Navigation</a></li>
+          <li><a href={`${path}/c-hamburger`}>Hamburger</a></li>
+          <li><a href={`${path}/c-header`}>Header</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-hamburger.astro
+++ b/src/pages/component-guide/c-hamburger.astro
@@ -1,0 +1,11 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Hamburger from '../../components/Hamburger.astro'
+---
+<ComponentGuideLayout title="Hamburger">
+  <section>
+    <p>スマホビューのときだけ表示されます。</p>
+    <Hamburger />
+  </section>
+</ComponentGuideLayout>

--- a/src/pages/component-guide/c-header.astro
+++ b/src/pages/component-guide/c-header.astro
@@ -1,0 +1,11 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Header from '../../components/Header.astro'
+---
+<ComponentGuideLayout title="Header">
+  <section>
+    <p>ヘッダーはスタイルの都合でページ上部に表示されてます。</p>
+    <Header />
+  </section>
+</ComponentGuideLayout>

--- a/src/pages/component-guide/c-navigation.astro
+++ b/src/pages/component-guide/c-navigation.astro
@@ -1,0 +1,10 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Navigation from '../../components/Navigation.astro'
+---
+<ComponentGuideLayout title="Navigation">
+  <section>
+    <Navigation />
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
- navigationコンポーネント追加
- hamburgerコンポーネント追加
- headerコンポーネント追加
- メニュー開閉実装

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=151%3A5883&mode=design&t=gFUPELt2mSioBvvw-1)

## プレビュー
- [navigation](https://deploy-preview-43--ellie-in-house-portfolio.netlify.app/component-guide/c-navigation/)
- [hamburger](https://deploy-preview-43--ellie-in-house-portfolio.netlify.app/component-guide/c-hamburger/)
- [header](https://deploy-preview-43--ellie-in-house-portfolio.netlify.app/component-guide/c-header/)

## その他