### PR TITLE
consultItemコンポーネント追加

### DIFF
--- a/src/components/ConsultItem.astro
+++ b/src/components/ConsultItem.astro
@@ -1,0 +1,13 @@
+---
+import Stack from "./Stack.astro"
+---
+<Stack className="c-consult-item" direction="column" gap={{sm: "2rem", md: "2.4rem", lg: "2.4rem"}}>
+  <slot />
+</Stack>
+
+<style>
+  :global(.c-consult-item) {
+    padding: var(--space-l);
+    background: var(--color-background-default);
+  }
+</style>

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -69,6 +69,7 @@ import SwitchTheme from '../components/Switch/SwitchTheme.astro';
           <li><a href={`${path}/c-skill-item`}>SkillItem</a></li>
           <li><a href={`${path}/c-work-thumbnail`}>WorkThumbnail</a></li>
           <li><a href={`${path}/c-work-item`}>WorkItem</a></li>
+          <li><a href={`${path}/c-consult-item`}>ConsultItem</a></li>
           <li><a href={`${path}/c-navigation`}>Navigation</a></li>
           <li><a href={`${path}/c-hamburger`}>Hamburger</a></li>
           <li><a href={`${path}/c-header`}>Header</a></li>

--- a/src/pages/component-guide/c-consult-item.astro
+++ b/src/pages/component-guide/c-consult-item.astro
@@ -1,0 +1,23 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import ConsultItem from '../../components/ConsultItem.astro'
+import Typography from '../../components/Typography.astro'
+import Stack from '../../components/Stack.astro'
+import List from '../../components/List.astro'
+
+---
+<ComponentGuideLayout title="ConsultItem">
+  <section>
+    <ConsultItem>
+      <Typography size="body-l" weight="bold">デザイン</Typography>
+      <Stack as="ul" direction="column">
+        <List variants="check">制作途中だが相談がしたい</List>
+        <List variants="check">客観的な意見・デザインレビューしてほしい</List>
+        <List variants="check">コーディングで実現可能なデザインか相談したい</List>
+        <List variants="check">デザイナー不在案件のUIなど調整してほしい</List>
+        <List variants="check">デザインツールの使い方を教えてほしい</List>
+      </Stack>
+    </ConsultItem>
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
consultItemコンポーネント追加

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=161%3A5982&mode=design&t=qASV4CKkyJnoSkbG-1)

## プレビュー
https://deploy-preview-45--ellie-in-house-portfolio.netlify.app/component-guide/c-consult-item/

## その他
stackなどにclassのpropsを用意して、そのclassに対してstyleを付与してもスタイルが反映されない。
解決法をしては`:global(クラス名)`で対応。（多分良くないけど仕方なし...）