### PR TITLE
Chatコンポーネント追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.5.10",
         "astro": "^4.5.12",
+        "gsap": "^3.12.5",
         "typescript": "^5.4.3"
       },
       "devDependencies": {
@@ -3920,6 +3921,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/gsap": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.12.5.tgz",
+      "integrity": "sha512-srBfnk4n+Oe/ZnMIOXt3gT605BX9x5+rh/prT2F1SsNJsU1XuMiP0E2aptW481OnonOGACZWBqseH5Z7csHxhQ=="
     },
     "node_modules/has-flag": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/check": "^0.5.10",
     "astro": "^4.5.12",
+    "gsap": "^3.12.5",
     "typescript": "^5.4.3"
   },
   "devDependencies": {

--- a/src/components/Chat/Chat.astro
+++ b/src/components/Chat/Chat.astro
@@ -1,0 +1,17 @@
+---
+import Stack from '../Stack.astro';
+---
+<div class="chat">
+  <slot />
+</div>
+
+<style>
+  .chat {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xl-3);
+    max-width: 480px;
+    width: 100%;
+    margin: auto;
+  }
+</style>

--- a/src/components/Chat/Chat.astro
+++ b/src/components/Chat/Chat.astro
@@ -1,15 +1,38 @@
 ---
-import Stack from '../Stack.astro';
 ---
-<div class="chat">
+<div class="c-chat">
   <slot />
 </div>
 
+<script>
+  import { gsap } from 'gsap';
+  import { ScrollTrigger } from "gsap/ScrollTrigger";
+  gsap.registerPlugin(ScrollTrigger);
+
+  const balloons = document.querySelectorAll('.c-message-balloon');
+
+  balloons.forEach((balloon) => {
+    gsap.from(balloon, {
+      y: 100,
+      scale: 0,
+      ease: "back.out(1.7)",
+      scrollTrigger: {
+        trigger: balloon,
+        start: "top bottom",
+        end: "center 70%",
+        scrub: true,
+        markers: false,
+      }
+    });
+  });
+</script>
+
+
 <style>
-  .chat {
+  .c-chat {
     display: flex;
     flex-direction: column;
-    gap: var(--space-xl-3);
+    gap: calc(var(--space-xl-4) * 1.5);
     max-width: 480px;
     width: 100%;
     margin: auto;

--- a/src/components/Chat/ChatItem.astro
+++ b/src/components/Chat/ChatItem.astro
@@ -8,7 +8,7 @@
   .c-chat-item {
     display: flex;
     flex-direction: column;
-    gap: var(--space-l);
+    gap: var(--space-xl);
 
     .c-message-balloon {
       &.theirs {

--- a/src/components/Chat/ChatItem.astro
+++ b/src/components/Chat/ChatItem.astro
@@ -1,0 +1,23 @@
+---
+---
+<div class="c-chat-item">
+  <slot />
+</div>
+
+<style>
+  .c-chat-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-l);
+
+    .c-message-balloon {
+      &.theirs {
+        margin-right: auto;
+      }
+
+      &.mine {
+        margin-left: auto;
+      }
+    }
+  }
+</style>

--- a/src/components/MessageBalloon.astro
+++ b/src/components/MessageBalloon.astro
@@ -21,7 +21,7 @@ const {
     max-width: 320px;
     padding: var(--space-m) var(--space-xl);
     background: var(--color-background-inset);
-    border-radius: var(--round-full);
+    border-radius: calc(var(--round-l) * 2);
     position: relative;
 
     > svg {

--- a/src/layouts/ComponentguideLayout.astro
+++ b/src/layouts/ComponentguideLayout.astro
@@ -75,6 +75,7 @@ import SwitchTheme from '../components/Switch/SwitchTheme.astro';
           <li><a href={`${path}/c-header`}>Header</a></li>
           <li><a href={`${path}/c-footer`}>Footer</a></li>
           <li><a href={`${path}/c-mv`}>MV</a></li>
+          <li><a href={`${path}/c-chat`}>Chat</a></li>
         </ul>
       </nav>
       <main class="main">

--- a/src/pages/component-guide/c-chat.astro
+++ b/src/pages/component-guide/c-chat.astro
@@ -15,12 +15,38 @@ import MessageBalloon from '../../components/MessageBalloon.astro';
     </p>
     <Chat>
       <ChatItem>
-        <MessageBalloon>テキストが入ります</MessageBalloon>
-        <MessageBalloon type="mine">テキストが入ります</MessageBalloon>
+        <MessageBalloon>名前は？</MessageBalloon>
+        <MessageBalloon type="mine">新田 詩織</MessageBalloon>
       </ChatItem>
       <ChatItem>
-        <MessageBalloon>テキストが入ります</MessageBalloon>
-        <MessageBalloon type="mine">テキストが入ります</MessageBalloon>
+        <MessageBalloon>どう呼ばれてるの？</MessageBalloon>
+        <MessageBalloon type="mine">にったさん、にったちゃん</MessageBalloon>
+      </ChatItem>
+      <ChatItem>
+        <MessageBalloon>ハンドルネームは？</MessageBalloon>
+        <MessageBalloon type="mine">ellie</MessageBalloon>
+      </ChatItem>
+      <ChatItem>
+        <MessageBalloon>Impvに入ったきっかけは？</MessageBalloon>
+        <MessageBalloon type="mine">専門学生時代の後輩（住井くん）からの紹介</MessageBalloon>
+      </ChatItem>
+      <ChatItem>
+        <MessageBalloon>出身地は？</MessageBalloon>
+        <MessageBalloon type="mine">広島県</MessageBalloon>
+      </ChatItem>
+      <ChatItem>
+        <MessageBalloon>住んでる場所は？</MessageBalloon>
+        <MessageBalloon type="mine">
+          埼玉県本庄市<br>
+          <br>
+          群馬県の植民地と呼ばれてるよ
+        </MessageBalloon>
+      </ChatItem>
+      <ChatItem>
+        <MessageBalloon>趣味は？</MessageBalloon>
+        <MessageBalloon type="mine">
+          さんぽ、アニメ鑑賞、絵画鑑賞、図書館めぐり、スーパー銭湯、サウナ
+        </MessageBalloon>
       </ChatItem>
     </Chat>
   </section>

--- a/src/pages/component-guide/c-chat.astro
+++ b/src/pages/component-guide/c-chat.astro
@@ -1,0 +1,27 @@
+---
+import ComponentGuideLayout from '../../layouts/ComponentguideLayout.astro';
+
+import Chat from '../../components/Chat/Chat.astro'
+import ChatItem from '../../components/Chat/ChatItem.astro'
+import MessageBalloon from '../../components/MessageBalloon.astro';
+---
+<ComponentGuideLayout title="Chat">
+  <section>
+    <p>
+      チャットは2つのコンポーネントで形成してます。<br>
+      <br>
+      Chat：チャットのコンテナ<br>
+      ChatItem：受け答えをグルーピングした項目<br>
+    </p>
+    <Chat>
+      <ChatItem>
+        <MessageBalloon>テキストが入ります</MessageBalloon>
+        <MessageBalloon type="mine">テキストが入ります</MessageBalloon>
+      </ChatItem>
+      <ChatItem>
+        <MessageBalloon>テキストが入ります</MessageBalloon>
+        <MessageBalloon type="mine">テキストが入ります</MessageBalloon>
+      </ChatItem>
+    </Chat>
+  </section>
+</ComponentGuideLayout>


### PR DESCRIPTION
## 概要
Chatコンポーネント追加
gsapインストール

[デザイン](https://www.figma.com/file/YFVdUAWJLA6FQRo2mRKwAp/Design-System?type=design&node-id=161%3A5982&mode=design&t=qASV4CKkyJnoSkbG-1)

## プレビュー
https://deploy-preview-47--ellie-in-house-portfolio.netlify.app/component-guide/c-chat/

## その他