### PR TITLE
タイポグラフィをメディアで分けずに管理

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,35 +13,36 @@ body {
 }
 
 .heading-display {
-  font-size: 4rem;
+  font-size: clamp(4rem, 6vw, 8rem);
   font-weight: bold;
   line-height: 1.4;
   letter-spacing: 0.04em;
 }
 
 .heading-l {
-  font-size: 3.2rem;
+  font-size: clamp(3.2rem, 5vw, 4rem);
   font-weight: bold;
   line-height: 1.4;
   letter-spacing: 0.04em;
 }
 
 .heading-m {
-  font-size: 2.4rem;
+  font-size: clamp(2.4rem, 4vw, 3.2rem);
+
   font-weight: bold;
   line-height: 1.4;
   letter-spacing: 0.04em;
 }
 
 .heading-s {
-  font-size: 2rem;
+  font-size: clamp(2rem, 3vw, 2.4rem);
   font-weight: bold;
   line-height: 1.6;
   letter-spacing: 0.04em;
 }
 
 .heading-xs {
-  font-size: 1.6rem;
+  font-size: clamp(1.6rem, 2vw, 1.8rem);
   font-weight: bold;
   line-height: 1.6;
   letter-spacing: 0.04em;
@@ -142,26 +143,4 @@ body {
   width: auto;
   height: auto;
   fill: currentColor;
-}
-
-@media (min-width: 768px) {
-  .heading-display {
-    font-size: clamp(4rem, 2vw + 3rem, 6.4rem);
-  }
-
-  .heading-l {
-    font-size: clamp(3.2rem, 2vw + 2rem, 4rem);
-  }
-
-  .heading-m {
-    font-size: clamp(2.4rem, 2vw + 1.2rem, 3.2rem);
-  }
-
-  .heading-s {
-    font-size: clamp(2rem, 2vw + 0.6rem, 2.4rem);
-  }
-
-  .heading-xs {
-    font-size: clamp(1.6rem, 2vw, 1.8rem);
-  }
 }


### PR DESCRIPTION
## 概要
タイポグラフィで定義してるfont-sizeをメディアクエリで分けず一括で指定。

## プレビュー
https://deploy-preview-73--ellie-in-house-portfolio.netlify.app/

## その他